### PR TITLE
Handle missing JSON payload in chat endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -14,10 +14,11 @@ openai.api_key = os.getenv("OPENAI_API_KEY")
 @app.route("/chat", methods=["POST"])
 def chat():
     try:
-        user_message = request.json.get("message")
-
-        if not user_message:
+        data = request.get_json(silent=True)
+        if not data or "message" not in data:
             return jsonify({"error": "Campo 'message' é obrigatório no corpo da requisição."}), 400
+
+        user_message = data["message"]
 
         response = openai.ChatCompletion.create(
             model="gpt-4-0125-preview",

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -1,0 +1,20 @@
+import os
+import sys
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from app import app
+
+
+def test_chat_missing_message():
+    with app.test_client() as client:
+        response = client.post("/chat", json={})
+        assert response.status_code == 400
+        data = response.get_json()
+        assert "message" in data["error"]
+
+
+def test_chat_non_json_request():
+    with app.test_client() as client:
+        response = client.post("/chat", data="plain text", content_type="text/plain")
+        assert response.status_code == 400


### PR DESCRIPTION
## Summary
- ensure chat endpoint validates JSON body and message field
- add tests for missing message and non-JSON requests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897d0d1ac3c8324b39472ed621e383d